### PR TITLE
🐞 fix: use static text with class name

### DIFF
--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -13,7 +13,7 @@ export class InternalServerError extends Error {
     super('Um erro interno não esperado aconteceu', {
       cause
     })
-    this.name = this.constructor.name
+    this.name = 'InternalServerError'
     this.action = 'Entre em contato com o suporte.'
     this.statusCode = statusCode || 500
   }
@@ -36,7 +36,7 @@ export class ServiceError extends Error {
     super(message || 'Serviço indisponível no momento.', {
       cause
     })
-    this.name = this.constructor.name
+    this.name = 'ServiceError'
     this.action = 'Verifique se o serviço está disponível.'
     this.statusCode = 503
   }
@@ -57,7 +57,7 @@ export class MethodNotAllowedError extends Error {
 
   constructor() {
     super('Método não permitido para este endpoint.')
-    this.name = this.constructor.name
+    this.name = 'MethodNotAllowedError'
     this.action =
       'Verifique se o método HTTP enviado é válido para este endpoint.'
     this.statusCode = 405


### PR DESCRIPTION
Remove the `this.constructor.name` method, this function don't work in production and the name attribute returns an incorrect value

Issue: #9