### PR TITLE
🐛 fix: handle optional session token retrieval

### DIFF
--- a/src/app/api/v1/sessions/route.ts
+++ b/src/app/api/v1/sessions/route.ts
@@ -21,8 +21,8 @@ const postHandler = async (request: NextRequest) => {
 }
 
 const deleteHandler = async (request: NextRequest) => {
-  const sessionToken = request.cookies.get('session_id')!.value
-  const sessionObject = await session.findOneValidByToken(sessionToken)
+  const sessionToken = request.cookies.get('session_id')?.value
+  const sessionObject = await session.findOneValidByToken(sessionToken ?? '')
   const expiredSession = await session.expireById(sessionObject.id)
 
   const headers = controller.clearSessionCookie()

--- a/src/app/api/v1/user/route.ts
+++ b/src/app/api/v1/user/route.ts
@@ -5,9 +5,9 @@ import session from '@/server/models/session'
 import user from '@/server/models/user'
 
 const getHandler = async (request: NextRequest) => {
-  const sessionToken = request.cookies.get('session_id')!.value
+  const sessionToken = request.cookies.get('session_id')?.value
 
-  const sessionObject = await session.findOneValidByToken(sessionToken)
+  const sessionObject = await session.findOneValidByToken(sessionToken ?? '')
   const renewedSessionObject = await session.renew(sessionObject.id)
 
   const headers = controller.setSessionCookie(renewedSessionObject.token)


### PR DESCRIPTION
- update session token retrieval to handle potential null values
- ensure session object is fetched correctly even if token is absent